### PR TITLE
Add metrics to geopackage export

### DIFF
--- a/Marlin/Marlin/GeoPackage/GeoPackageExportView.swift
+++ b/Marlin/Marlin/GeoPackage/GeoPackageExportView.swift
@@ -146,6 +146,7 @@ struct GeoPackageExportView: View {
         .background(Color.backgroundColor)
         .onAppear {
             exporter.setExportRequests(exportRequests: exportRequest)
+            Metrics.shared.geoPackageExportView()
         }
     }
 }

--- a/Marlin/Marlin/GeoPackage/GeoPackageExporter.swift
+++ b/Marlin/Marlin/GeoPackage/GeoPackageExporter.swift
@@ -146,6 +146,7 @@ class GeoPackageExporter: ObservableObject {
         exporting = true
         complete = false
         backgroundExport()
+        Metrics.shared.geoPackageExport(dataSources: filterViewModels.map(\.dataSource))
     }
     
     private func backgroundExport() {

--- a/Marlin/Marlin/Metrics/Metrics.swift
+++ b/Marlin/Marlin/Metrics/Metrics.swift
@@ -92,6 +92,24 @@ class Metrics {
         appRoute(["\(dataSource.metricsKey)", "detail"])
     }
     
+    func geoPackageExportView() {
+        NSLog("Record GeoPackage Export View")
+        appRoute(["geoPackageExport"])
+    }
+    
+    func geoPackageExport(dataSources: [any DataSource.Type]) {
+        NSLog("Record GeoPackage Export - \(dataSources.map {$0.key}.joined(separator: ","))")
+        if let tracker = MatomoTracker.shared {
+            let event = Event(tracker: tracker,
+                              action: ["export geopackage"],
+                              eventCategory: "download",
+                              eventAction: "export geopackage",
+                              eventName: dataSources.map {$0.metricsKey}.joined(separator: ","),
+                              isCustomAction: true )
+            MatomoTracker.shared?.track(event)
+        }
+    }
+    
     func search(query: String, resultCount: Int) {
         NSLog("Record search")
         MatomoTracker.shared?.trackSearch(query: query, category: nil, resultCount: resultCount)


### PR DESCRIPTION
+ Add tracking metric when geopackage export view loads
+ Adds event metric when exporting a geopackage. The event name contains the selected data sources