### PR TITLE
Resolve nav warning isses

### DIFF
--- a/Marlin/Marlin.xcodeproj/project.pbxproj
+++ b/Marlin/Marlin.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		7982FB9B536447055E423E94 /* libPods-Marlin.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B0F14076A8393C9747AD1FE /* libPods-Marlin.a */; };
+		D67E5C9A2A9E4AA5002FCE03 /* MKPolygonExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67E5C992A9E4AA5002FCE03 /* MKPolygonExtensions.swift */; };
 		D7A569C784B0F2D5720432C4 /* libPods-MarlinTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 96BF65BCD73E70E253A09CB6 /* libPods-MarlinTests.a */; };
 		F7066DA92A45D8C10058122E /* GeoPackageExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7066DA82A45D8C10058122E /* GeoPackageExporter.swift */; };
 		F7066DAB2A462A740058122E /* GeoPackageExportable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7066DAA2A462A740058122E /* GeoPackageExportable.swift */; };
@@ -446,6 +447,7 @@
 		34DEDF107D4BA2A7D7541968 /* Pods-Marlin.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Marlin.debug.xcconfig"; path = "Target Support Files/Pods-Marlin/Pods-Marlin.debug.xcconfig"; sourceTree = "<group>"; };
 		96BF65BCD73E70E253A09CB6 /* libPods-MarlinTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-MarlinTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		C95BD18A52FCC50ED2ED6E21 /* Pods-MarlinTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MarlinTests.release.xcconfig"; path = "Target Support Files/Pods-MarlinTests/Pods-MarlinTests.release.xcconfig"; sourceTree = "<group>"; };
+		D67E5C992A9E4AA5002FCE03 /* MKPolygonExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MKPolygonExtensions.swift; sourceTree = "<group>"; };
 		F32BF352638699CBFE1A8D52 /* Pods-Marlin.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Marlin.release.xcconfig"; path = "Target Support Files/Pods-Marlin/Pods-Marlin.release.xcconfig"; sourceTree = "<group>"; };
 		F7066DA82A45D8C10058122E /* GeoPackageExporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeoPackageExporter.swift; sourceTree = "<group>"; };
 		F7066DAA2A462A740058122E /* GeoPackageExportable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeoPackageExportable.swift; sourceTree = "<group>"; };
@@ -1836,6 +1838,7 @@
 				F70BCEA829DEFDA800AEF73D /* DoubleExtensions.swift */,
 				F7BEE47D2A0443D200EC282D /* MKShapeExtensions.swift */,
 				F7EB1B0D2A0D7FC200D1433B /* SFGeometryExtensions.swift */,
+				D67E5C992A9E4AA5002FCE03 /* MKPolygonExtensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2515,6 +2518,7 @@
 				F7F597B22866248700F9B32E /* NavigationalWarningNavAreaListView.swift in Sources */,
 				F7FFB34128DA486500C31AA3 /* FilterView.swift in Sources */,
 				F75E32BF29C4BC00006F2394 /* LayerURLView.swift in Sources */,
+				D67E5C9A2A9E4AA5002FCE03 /* MKPolygonExtensions.swift in Sources */,
 				F7FFB2F428D62A5000C31AA3 /* Port+Annotation.swift in Sources */,
 				F7364E362A1D53970098F243 /* MapNavigationView.swift in Sources */,
 				F7FFB2EA28D623B000C31AA3 /* DifferentialGPSStation+DataSource.swift in Sources */,

--- a/Marlin/Marlin/DataSources/NavigationalWarning/NAVTEXTextParser.swift
+++ b/Marlin/Marlin/DataSources/NavigationalWarning/NAVTEXTextParser.swift
@@ -69,7 +69,7 @@ struct LocationWithType: CustomStringConvertible {
                     points.append(MKMapPoint(coordinate))
                 }
             }
-            return MKPolygon(points: &points, count: points.count)
+            return MKPolygon(points: &points, count: points.count).toGeodesicPolyline()
         } else if locationType == "LineString" {
             for locationPoint in location {
                 if let coordinate = CLLocationCoordinate2D(coordinateString: locationPoint) {

--- a/Marlin/Marlin/DataSources/NavigationalWarning/NavigationalWarning+DataSource.swift
+++ b/Marlin/Marlin/DataSources/NavigationalWarning/NavigationalWarning+DataSource.swift
@@ -145,7 +145,7 @@ extension NavigationalWarning: DataSourceLocation, GeoPackageExportable {
     
     static func getBoundingPredicate(minLat: Double, maxLat: Double, minLon: Double, maxLon: Double) -> NSPredicate {
         return NSPredicate(
-            format: "maxLatitude >= %lf AND minLatitude <= %lf AND maxLongitude >= %lf AND minLongitude <= %lf", minLat, maxLat, minLon, maxLon
+            format: "(maxLatitude >= %lf AND minLatitude <= %lf AND maxLongitude >= %lf AND minLongitude <= %lf) OR minLongitude < -180 OR maxLongitude > 180", minLat, maxLat, minLon, maxLon
         )
     }
     

--- a/Marlin/Marlin/Extensions/CLLocationCoordinate2DExtensions.swift
+++ b/Marlin/Marlin/Extensions/CLLocationCoordinate2DExtensions.swift
@@ -104,12 +104,12 @@ extension CLLocationCoordinate2D {
         return coordinates
     }
     
-    func toPixel(zoomLevel: Int, tileBounds3857: MapBoundingBox, tileSize: Double) -> CGPoint {
+    func toPixel(zoomLevel: Int, tileBounds3857: MapBoundingBox, tileSize: Double, canCross180thMeridian: Bool = true) -> CGPoint {
         var object3857Location = to3857()
         
         // TODO: this logic should be improved
         // just check on the edges of the world presuming that no light will span 90 degrees, which none will
-        if longitude < -90 || longitude > 90 {
+        if canCross180thMeridian && (longitude < -90 || longitude > 90) {
             // if the x location has fallen off the left side and this tile is on the other side of the world
             if object3857Location.x > tileBounds3857.swCorner.x && tileBounds3857.swCorner.x < 0 && object3857Location.x > 0 {
                 let newCoordinate = CLLocationCoordinate2D(latitude: self.latitude, longitude: self.longitude - 360.0)

--- a/Marlin/Marlin/Extensions/MKPolygonExtensions.swift
+++ b/Marlin/Marlin/Extensions/MKPolygonExtensions.swift
@@ -1,0 +1,48 @@
+//
+//  MKPolygonExtensions.swift
+//  Marlin
+//
+//  Created by Joshua Nelson on 8/29/23.
+//
+
+import Foundation
+import MapKit
+
+extension MKPolygon {
+    
+    static func buildGeodesicPolyline(points: UnsafePointer<MKMapPoint>, pointCount: Int) -> MKGeodesicPolyline {
+        var pointsToConnect = Array(UnsafeBufferPointer(start: points, count: pointCount))
+        
+        // connect the final point back to the first with a geodesic polyline
+        pointsToConnect.append(pointsToConnect[0])
+        
+        return MKGeodesicPolyline(points: pointsToConnect, count: pointsToConnect.count)
+    }
+    
+    func toGeodesicPolyline() -> MKGeodesicPolyline {
+        return MKPolygon.buildGeodesicPolyline(points: points(), pointCount: pointCount)
+    }
+    
+    func getGeodesicClickAreas() -> [MKGeodesicPolyline] {
+        var clickAreas: [MKGeodesicPolyline] = []
+        let points = Array<MKMapPoint>(UnsafeBufferPointer(start: points(), count: pointCount))
+        clickAreas.append(MKPolygon.buildGeodesicPolyline(points: points, pointCount: points.count))
+        
+        // check for meridian/antimeridian crossing
+        var crossesAtIndex = -1
+        for i in 0..<points.count {
+            if points[i].coordinate.longitude.sign != points[0].coordinate.longitude.sign {
+                crossesAtIndex = i
+                break
+            }
+        }
+        
+        // if shape crosses a meridian, add another click area starting from the other side of the meridian
+        if(crossesAtIndex > -1){
+            let reorderedPoints: [MKMapPoint] = points.dropFirst(crossesAtIndex) + points.dropLast(points.count - crossesAtIndex)
+            clickAreas.append(MKPolygon.buildGeodesicPolyline(points: reorderedPoints, pointCount: reorderedPoints.count))
+        }
+        
+        return clickAreas
+    }
+}

--- a/Marlin/Marlin/Map/Mixins/MapMixin.swift
+++ b/Marlin/Marlin/Map/Mixins/MapMixin.swift
@@ -41,6 +41,16 @@ extension MapMixin {
         return onShape
     }
     
+    func polygonHitTest(closedPolyline: MKGeodesicPolyline, location: CLLocationCoordinate2D) -> Bool {
+        guard let renderer = (renderer(overlay: closedPolyline) as? MKPolylineRenderer ?? standardRenderer(overlay: closedPolyline) as? MKPolylineRenderer) else {
+            return false
+        }
+        let mapPoint = MKMapPoint.init(location)
+        let point = renderer.point(for: mapPoint)
+        let onShape = renderer.path?.contains(point) ?? false
+        return onShape
+    }
+    
     func lineHitTest(line: MKPolyline, location: CLLocationCoordinate2D, tolerance: Double) -> Bool {
         guard let renderer = (renderer(overlay: line) as? MKPolylineRenderer ?? standardRenderer(overlay: line) as? MKPolylineRenderer) else {
             return false

--- a/Marlin/Marlin/Map/Mixins/NavigationalWarningMap.swift
+++ b/Marlin/Marlin/Map/Mixins/NavigationalWarningMap.swift
@@ -101,8 +101,10 @@ class NavigationalWarningFetchMap<T: NavigationalWarning & MapImage>: FetchReque
                     }
                     if let shape = MKShape.fromWKT(wkt: wkt, distance: distance) {
                         if let polygon = shape as? MKPolygon {
-                            if polygonHitTest(polygon: polygon, location: location) {
-                                return true
+                            for polyline in polygon.getGeodesicClickAreas() {
+                                if polygonHitTest(closedPolyline: polyline, location: location) {
+                                    return true
+                                }
                             }
                         } else if let polyline = shape as? MKPolyline {
                             if lineHitTest(line: polyline, location: location, tolerance: tolerance * 2.0) {


### PR DESCRIPTION
- Resolve issues where nav warnings crossing the prime meridian or 180th meridian could not be tapped
- Fix issue where nav warnings that cross the 90th meridian (east or west) and approach or cross the prime meridian or 180th meridian generated buggy rectangles in adjacent map tiles